### PR TITLE
关闭前一个响应

### DIFF
--- a/autojs/src/main/java/com/stardust/autojs/core/http/MutableOkHttp.java
+++ b/autojs/src/main/java/com/stardust/autojs/core/http/MutableOkHttp.java
@@ -25,6 +25,9 @@ public class MutableOkHttp extends OkHttpClient {
         do {
             boolean succeed;
             try {
+                if (response != null) {
+                    response.close();
+                }
                 response = chain.proceed(request);
                 succeed = response.isSuccessful();
             } catch (SocketTimeoutException e) {


### PR DESCRIPTION
解决 java.lang.IllegalStateException: cannot make a new request because the previous response is still open: please call response.close()